### PR TITLE
Geokodierung von Fahrradbügel 561 angepasst

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -559,7 +559,7 @@ id;Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 558;2;A;N;N;Geh;2019;Thomasstraße 67;Anlehnbügel 2018 (SenUVK);52.472054;13.431179
 559;6;A;N;N;F;2019;Treptower Straße 19;Anlehnbügel 2018 (SenUVK);52.480133;13.451043
 560;3;A;N;N;Geh;2019;Treptower Straße 68;Anlehnbügel 2018 (SenUVK);52.482758;13.454052
-561;3;A;N;N;F;2019;Uthmannstraße 15;Anlehnbügel 2018 (SenUVK);52.475414;13.441359
+561;3;A;N;N;F;2019;Uthmannstraße 15;Anlehnbügel 2018 (SenUVK);52.4753930,13.4406447
 562;3;A;N;N;Geh;2019;Warthestraße 12;Anlehnbügel 2018 (SenUVK);52.470123;13.426442
 563;3;A;N;N;Geh;2019;Warthestraße 62;Anlehnbügel 2018 (SenUVK);52.469803;13.426306
 564;3;A;N;N;Geh;2019;Wederstraße 87;Anlehnbügel 2018 (SenUVK);52.462044;13.435679


### PR DESCRIPTION
Der Bügel ist vor Haus 21 aufgetaucht. Die offiziellen Daten habe ich bei 15 gelassen, aber die Geokoordinaten auf https://www.openstreetmap.org/way/824532572 geändert, so dass die App den richtigen Bügel vergleicht.